### PR TITLE
[GHP-4192] Support Rails controller caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+.ruby-version
+.bundle
+vendor
+Gemfile.lock
+coverage
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   NewCops: enable
 
 Metrics/BlockLength:
@@ -7,6 +7,9 @@ Metrics/BlockLength:
 
 Metrics/MethodLength:
   Max: 100
+
+Style/ExplicitBlockArgument:
+  Enabled: false
 
 Style/GuardClause:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in idempotency.gemspec
 gemspec
 
-gem 'rake', '~> 13.0'
-
+gem 'mock_redis'
 gem 'rspec', '~> 3.0'
 
-gem 'debug'
+gem 'connection_pool'
+gem 'pry-byebug'
 gem 'rubocop', '~> 1.21'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,35 +2,49 @@ PATH
   remote: .
   specs:
     idempotency (0.1.0)
+      dry-configurable
+      msgpack
+      redis
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    debug (1.9.2)
-      irb (~> 1.10)
-      reline (>= 0.3.8)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
     diff-lcs (1.5.1)
-    io-console (0.7.2)
-    irb (1.14.1)
-      rdoc (>= 4.0.0)
-      reline (>= 0.4.2)
+    dry-configurable (1.2.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-core (1.0.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
     json (2.8.1)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
+    method_source (1.1.0)
+    mock_redis (0.46.0)
+    msgpack (1.7.5)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
-    psych (5.2.0)
-      stringio
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
-    rdoc (6.7.0)
-      psych (>= 4.0.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.2)
-    reline (0.5.11)
-      io-console (~> 0.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -57,17 +71,18 @@ GEM
     rubocop-ast (1.35.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    stringio (3.1.2)
     unicode-display_width (2.6.0)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   arm64-darwin-21
   ruby
 
 DEPENDENCIES
-  debug
+  connection_pool
   idempotency!
-  rake (~> 13.0)
+  mock_redis
+  pry-byebug
   rspec (~> 3.0)
   rubocop (~> 1.21)
 

--- a/idempotency.gemspec
+++ b/idempotency.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://www.ascenda.com'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -33,4 +33,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
   spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.add_dependency 'dry-configurable'
+  spec.add_dependency 'msgpack'
+  spec.add_dependency 'redis'
 end

--- a/lib/idempotency.rb
+++ b/lib/idempotency.rb
@@ -1,4 +1,24 @@
 # frozen_string_literal: true
 
+require 'dry-configurable'
+require 'json'
+require_relative 'idempotency/cache'
+require_relative 'idempotency/rails'
+
 module Idempotency
+  extend Dry::Configurable
+
+  setting :redis_pool
+  setting :default_lock_expiry
+  setting :logger
+
+  setting :response_body do
+    setting :concurrent_error, default: {
+      errors: [{ message: 'Request conflicts with another likely concurrent request.' }]
+    }.to_json
+  end
+
+  def self.cache
+    @cache ||= Cache.new(config:)
+  end
 end

--- a/lib/idempotency/cache.rb
+++ b/lib/idempotency/cache.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'redis'
+require 'msgpack'
+
+module Idempotency
+  class Cache
+    class LockConflict < StandardError; end
+
+    DEFAULT_CACHE_EXPIRY = 86_400 # seconds = 1 hour
+
+    COMPARE_AND_DEL_SCRIPT = <<-SCRIPT
+        local value = ARGV[1]
+        local cached_value = redis.call('GET', KEYS[1])
+
+        if( value == cached_value )
+        then
+            redis.call('DEL', KEYS[1])
+            return value
+        end
+
+        return cached_value
+    SCRIPT
+    COMPARE_AND_DEL_SCRIPT_SHA = Digest::SHA1.hexdigest(COMPARE_AND_DEL_SCRIPT)
+
+    def initialize(config: Idempotency.config)
+      @logger = config.logger
+      @redis_pool = config.redis_pool
+    end
+
+    def get(fingerprint)
+      key = response_cache_key(fingerprint)
+
+      cached_response = with_redis do |r|
+        r.get(key)
+      end
+
+      deserialize(cached_response) if cached_response
+    end
+
+    def set(fingerprint, response)
+      key = response_cache_key(fingerprint)
+
+      with_redis do |r|
+        r.set(key, serialize(response))
+      end
+    end
+
+    def with_lock(fingerprint, duration)
+      acquired_lock = lock(fingerprint, duration)
+      yield
+    ensure
+      release_lock(fingerprint, acquired_lock) if acquired_lock
+    end
+
+    def lock(fingerprint, duration)
+      random_value = SecureRandom.hex
+      key = lock_key(fingerprint)
+
+      lock_acquired = with_redis do |r|
+        r.set(key, random_value, nx: true, ex: duration || Idempotency.config.default_lock_expiry)
+      end
+
+      raise LockConflict unless lock_acquired
+
+      random_value
+    end
+
+    def release_lock(fingerprint, acquired_lock)
+      with_redis do |r|
+        lock_released = r.evalsha(COMPARE_AND_DEL_SCRIPT_SHA, keys: [lock_key(fingerprint)], argv: [acquired_lock])
+        raise LockConflict if lock_released != acquired_lock
+      rescue Redis::CommandError => e
+        if e.message.include?('NOSCRIPT')
+          # The Redis server has never seen this script before. Needs to run only once in the entire lifetime
+          # of the Redis server, until the script changes - in which case it will be loaded under a different SHA
+          r.script(:load, COMPARE_AND_DEL_SCRIPT)
+          retry
+        else
+          raise e
+        end
+      end
+    end
+
+    private
+
+    def with_redis(&)
+      redis_pool.with(&)
+    rescue Redis::ConnectionError, Redis::CannotConnectError => e
+      logger.error(e.message)
+      nil
+    end
+
+    def response_cache_key(fingerprint)
+      "idempotency:cached_response:#{fingerprint}"
+    end
+
+    def lock_key(fingerprint)
+      "idempotency:lock:#{fingerprint}"
+    end
+
+    def serialize(response)
+      cache_data = [response.status, response.body, response.headers]
+      MessagePack.pack(cache_data)
+    end
+
+    def deserialize(cached_response)
+      MessagePack.unpack(cached_response)
+    end
+
+    attr_reader :redis_pool, :logger
+  end
+end

--- a/lib/idempotency/constants.rb
+++ b/lib/idempotency/constants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Idempotency
+  class Constants
+    HEADER_KEY = 'Idempotency-Key'
+  end
+end

--- a/lib/idempotency/rails.rb
+++ b/lib/idempotency/rails.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'base64'
+require_relative 'constants'
+
+module Idempotency
+  module Rails
+    def use_cache(request_identifiers = [], lock_duration: nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      return yield unless cache_request?(request)
+
+      cache = Idempotency.cache
+
+      idempotency_key = unquote(request.headers[Constants::HEADER_KEY] || SecureRandom.hex)
+
+      fingerprint = calculate_fingerprint(request, idempotency_key, request_identifiers)
+
+      cached_response = cache.get(fingerprint)
+      return set_response(response, *cached_response) if cached_response
+
+      cache.with_lock(fingerprint, lock_duration || Idempotency.config.default_lock_expiry) do
+        yield
+      end
+
+      if cache_response?(response)
+        response.headers[Constants::HEADER_KEY] = idempotency_key
+        cache.set(fingerprint, response) if cache_response?(response)
+      end
+    rescue Idempotency::Cache::LockConflict
+      render(**duplicated_concurrent_request_error)
+    end
+
+    def calculate_fingerprint(request, idempotency_key, request_identifiers)
+      d = Digest::SHA256.new
+      d << idempotency_key
+      d << request.path
+      d << request.method
+
+      request_identifiers.each do |identifier|
+        d << identifier
+      end
+
+      Base64.strict_encode64(d.digest)
+    end
+
+    private
+
+    def set_response(response, status, body, headers)
+      response.status = status
+      response.body = body
+      headers.each do |key, value|
+        response.set_header(key, value)
+      end
+    end
+
+    def cache_request?(request)
+      request.method == 'POST'
+    end
+
+    def cache_response?(response)
+      (200..299).include?(response.status) || (400..499).include?(response.status)
+    end
+
+    def duplicated_concurrent_request_error
+      {
+        json: Idempotency.config.response_body.concurrent_error,
+        status: 409
+      }
+    end
+
+    def unquote(str)
+      double_quote = '"'
+      if str.start_with?(double_quote) && str.end_with?(double_quote)
+        str[1..-2]
+      else
+        str
+      end
+    end
+  end
+end

--- a/spec/idempotency/cache_spec.rb
+++ b/spec/idempotency/cache_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Idempotency::Cache do
+  Response = Struct.new(:status, :body, :headers) # rubocop:disable Lint/ConstantDefinitionInBlock
+
+  before do
+    Idempotency.configure do |config|
+      config.redis_pool = ConnectionPool.new { mock_redis }
+    end
+  end
+
+  after { Idempotency.reset_config }
+
+  let(:cache) { described_class.new }
+
+  let(:mock_redis) { MockRedis.new }
+  let(:fingerprint) { SecureRandom.hex }
+
+  describe '#get' do
+    subject { cache.get(fingerprint) }
+
+    context 'when there is data' do
+      let(:response) { Response.new(response_status, response_body, response_headers) }
+      let(:response_status) { 200 }
+      let(:response_body) { { result: 'some_result' }.to_json }
+      let(:response_headers) { { 'header' => 'valuee' } }
+
+      before do
+        cache.set(fingerprint, response)
+      end
+
+      it { is_expected.to eq([response_status, response_body, response_headers]) }
+    end
+
+    context 'when there is no data' do
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#set' do
+    subject { cache.set(fingerprint, response) }
+
+    let(:response) { Response.new(response_status, response_body, response_headers) }
+    let(:response_status) { 200 }
+    let(:response_body) { { result: 'some_result' }.to_json }
+    let(:response_headers) { { 'header' => 'valuee' } }
+
+    it 'sets data in cache correctly' do
+      is_expected.to eq('OK')
+      expect(cache.get(fingerprint)).to eq([response_status, response_body, response_headers])
+    end
+  end
+
+  describe '#lock' do
+    subject { cache.lock(fingerprint, 10) }
+
+    let(:random_value) { SecureRandom.hex }
+    let(:cache_key) { "idempotency:lock:#{fingerprint}" }
+
+    context 'when lock is already owned' do
+      before do
+        mock_redis.set(cache_key, SecureRandom.hex)
+      end
+
+      it { expect { subject }.to raise_error(Idempotency::Cache::LockConflict) }
+    end
+
+    context 'when lock is not owned' do
+      it { expect { subject }.to change { mock_redis.get(cache_key) }.from(nil).to(be_a(String)) }
+    end
+  end
+
+  describe '#release_lock' do
+    subject { cache.release_lock(fingerprint, acquired_lock) }
+
+    let(:acquired_lock) { SecureRandom.hex }
+
+    before do
+      expect(mock_redis)
+        .to receive(:evalsha).with(
+          Idempotency::Cache::COMPARE_AND_DEL_SCRIPT_SHA,
+          keys: ["idempotency:lock:#{fingerprint}"],
+          argv: [acquired_lock]
+        ).and_return(current_lock)
+    end
+
+    context 'when acquired lock is different from current lock' do
+      let(:current_lock) { SecureRandom.hex }
+
+      it { expect { subject }.to raise_error(Idempotency::Cache::LockConflict) }
+    end
+
+    context 'when acquired lock is the same as current lock' do
+      let(:current_lock) { acquired_lock }
+
+      it { expect { subject }.not_to raise_error }
+    end
+  end
+end

--- a/spec/idempotency/rails_spec.rb
+++ b/spec/idempotency/rails_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+RSpec.describe Idempotency::Rails do
+  class ApplicationController # rubocop:disable Lint/ConstantDefinitionInBlock
+    include Idempotency::Rails
+
+    def initialize(request, response)
+      @request = request
+      @response = response
+    end
+
+    def render(json:, status:)
+      response.body = json
+      response.status = status
+    end
+
+    private
+
+    attr_reader :request, :response
+  end
+
+  Response = Struct.new(:status, :body, :headers) do # rubocop:disable Lint/ConstantDefinitionInBlock
+    def set_header(key, value)
+      headers[key] = value
+    end
+  end
+
+  let(:controller) { ApplicationController.new(request, response) }
+  let(:mock_redis) { MockRedis.new }
+  let(:mock_controller_action) { double('Controller') }
+
+  subject do
+    controller.use_cache(request_identifiers, lock_duration:) do
+      mock_controller_action.call
+    end
+  end
+
+  let(:request_identifiers) { [SecureRandom.hex] }
+  let(:lock_duration) { 5 }
+
+  let(:request) do
+    double(
+      'ActionDispatch::Request',
+      method: request_method,
+      path: '/int/orders/a960e817-3b3c-487c-8db4-7a1d065f52b7',
+      headers: request_headers
+    )
+  end
+  let(:request_method) { 'POST' }
+  let(:request_headers) { { 'Idempotency-Key' => idempotency_key } }
+  let(:idempotency_key) { SecureRandom.uuid }
+
+  let(:response) { Response.new(response_status, response_body, response_headers) }
+  let(:response_status) { 200 }
+  let(:response_body) { { result: 'some_result' }.to_json }
+  let(:response_headers) { {} }
+
+  let(:fingerprint) do
+    d = Digest::SHA256.new
+    d << idempotency_key
+    d << request.path
+    d << request.method
+    d << request_identifiers.first
+    Base64.strict_encode64(d.digest)
+  end
+  let(:cache_key) { "idempotency:cached_response:#{fingerprint}" }
+  let(:cache) { Idempotency.cache }
+
+  context 'when request method is not POST' do
+    let(:request_method) { 'GET' }
+
+    before do
+      expect(mock_controller_action).to receive(:call)
+    end
+
+    it 'should not be cached' do
+      subject
+
+      expect(cache.get(cache_key)).to be_nil
+    end
+  end
+
+  context 'when request is cached' do
+    let(:response) { Response.new(nil, nil, {}) }
+    let(:cached_headers) { { 'key' => 'value' } }
+    let(:cached_status) { 201 }
+    let(:cached_body) { { offer_id: SecureRandom.uuid }.to_json }
+
+    before do
+      expect(mock_controller_action).not_to receive(:call)
+      cache.set(fingerprint, Response.new(cached_status, cached_body, cached_headers))
+    end
+
+    it 'returns cached request' do
+      subject
+
+      expect(response.headers).to eq(cached_headers)
+      expect(response.status).to eq(cached_status)
+      expect(response.body).to eq(cached_body)
+    end
+  end
+
+  context 'when request is not cached' do
+    let(:mock_controller_action) { double('Controller', call: 1) }
+    let(:response) { Response.new(response_status, response_body, response_headers) }
+
+    before do
+      expect(Idempotency.cache)
+        .to receive(:release_lock)
+        .with(fingerprint, be_a(String))
+    end
+
+    it 'caches request' do
+      subject
+
+      cached_status, cached_body, cached_headers = cache.get(fingerprint)
+      expect(cached_status).to eq(response_status)
+      expect(cached_body).to eq(response_body)
+      expect(cached_headers).to include({ 'Idempotency-Key' => be_a(String) })
+    end
+  end
+
+  context 'when response is 5xx' do
+    let(:mock_controller_action) { double('Controller', call: 1) }
+    let(:response) { Response.new(response_status, response_body, response_headers) }
+    let(:response_status) { 500 }
+
+    before do
+      expect(Idempotency.cache)
+        .to receive(:release_lock)
+        .with(fingerprint, be_a(String))
+    end
+
+    it { expect { subject }.not_to(change { cache.get(fingerprint) }) }
+  end
+
+  context 'when there is concurrent request' do
+    let(:response) { Response.new(nil, nil, nil) }
+    let(:mock_controller_action) { double('Controller', call: 1) }
+
+    it 'returns 409 error and does not cache request' do
+      subject
+
+      expect(cache.get(fingerprint)).to be_nil
+      expect(response.status).to eq(409)
+      expect(response.body).to eq(Idempotency.config.response_body.concurrent_error)
+    end
+  end
+end

--- a/spec/idempotency_spec.rb
+++ b/spec/idempotency_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Idempotency do
+  let(:redis_pool) { ConnectionPool.new { MockRedis.new } }
+  it 'has a version number' do
+    expect(Idempotency::VERSION).not_to be nil
+  end
+
+  after { Idempotency.reset_config }
+
+  it 'allows configuration' do
+    Idempotency.configure do |config|
+      config.redis_pool = redis_pool
+      config.default_lock_expiry = 60
+
+      config.response_body.concurrent_error = {
+        errors: [{ code: 'GH0004', message: 'Some message' }]
+      }
+    end
+
+    config = Idempotency.config
+    expect(config.redis_pool).to eq(redis_pool)
+    expect(config.default_lock_expiry).to eq(60)
+    expect(config.response_body.concurrent_error).to eq({ errors: [{ code: 'GH0004', message: 'Some message' }] })
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'idempotency'
+require 'pry-byebug'
+require 'mock_redis'
+require 'dry/configurable/test_interface'
+
+Idempotency.configure do |config|
+  config.redis_pool = ConnectionPool.new { MockRedis.new }
+  config.logger = Logger.new(nil)
+end
+
+module Idempotency
+  enable_test_interface
+
+  def self.reset_config
+    super
+    config.redis_pool = ConnectionPool.new { MockRedis.new }
+    config.logger = Logger.new(nil)
+  end
+end
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.order = :random
+end


### PR DESCRIPTION
## Context

Jira ticket: https://kaligo.atlassian.net/browse/GHP-4192

## Design

This PR implements the Rails portion of this RFC: https://www.notion.so/kaligo/RFC-Idempotency-gem-13031c5427fd80938030f2f5c56c9575?pvs=4

The overall design closely follows the RFC and, except the API `Idempotency#use_cache` now allow applications to assign additional values that identify the request (e.g. tenant_id)