### PR TITLE
[GHP-4209] Monkey patch Hanami around callback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ gem 'mock_redis'
 gem 'rspec', '~> 3.0'
 
 gem 'connection_pool'
+gem 'hanami-controller', '~> 1.3'
 gem 'pry-byebug'
 gem 'rubocop', '~> 1.21'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,12 @@ GEM
       concurrent-ruby (~> 1.0)
       logger
       zeitwerk (~> 2.6)
+    hanami-controller (1.3.3)
+      hanami-utils (~> 1.3)
+      rack (~> 2.0)
+    hanami-utils (1.3.8)
+      concurrent-ruby (~> 1.0)
+      transproc (~> 1.0)
     json (2.8.1)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
@@ -39,6 +45,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     racc (1.8.1)
+    rack (2.2.10)
     rainbow (3.1.1)
     redis (5.3.0)
       redis-client (>= 0.22.0)
@@ -71,6 +78,7 @@ GEM
     rubocop-ast (1.35.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    transproc (1.1.1)
     unicode-display_width (2.6.0)
     zeitwerk (2.6.18)
 
@@ -80,6 +88,7 @@ PLATFORMS
 
 DEPENDENCIES
   connection_pool
+  hanami-controller (~> 1.3)
   idempotency!
   mock_redis
   pry-byebug

--- a/lib/hanami/action/callbacks.rb
+++ b/lib/hanami/action/callbacks.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'hanami/utils/class_attribute'
+require 'hanami/utils/callbacks'
+
+if Gem.loaded_specs['hanami'] && !Gem::Dependency.new('', '~> 1.3').match?('', Hanami::VERSION)
+  raise 'idempotency gem only supports Hanami version 1.3.x'
+end
+
+module Hanami
+  module Action
+    # Before and after callbacks
+    #
+    # @since 0.1.0
+    # @see Hanami::Action::ClassMethods#before
+    # @see Hanami::Action::ClassMethods#after
+    module Callbacks
+      # Override Ruby's hook for modules.
+      # It includes callbacks logic
+      #
+      # @param base [Class] the target action
+      #
+      # @since 0.1.0
+      # @api private
+      #
+      # @see http://www.ruby-doc.org/core/Module.html#method-i-included
+      def self.included(base)
+        base.class_eval do
+          extend  ClassMethods
+          prepend InstanceMethods
+        end
+      end
+
+      # Callbacks API class methods
+      #
+      # @since 0.1.0
+      # @api private
+      module ClassMethods
+        # Override Ruby's hook for modules.
+        # It includes callbacks logic
+        #
+        # @param base [Class] the target action
+        #
+        # @since 0.1.0
+        # @api private
+        #
+        # @see http://www.ruby-doc.org/core/Module.html#method-i-extended
+        def self.extended(base)
+          base.class_eval do
+            include Utils::ClassAttribute
+
+            class_attribute :before_callbacks
+            self.before_callbacks = Utils::Callbacks::Chain.new
+
+            class_attribute :after_callbacks
+            self.after_callbacks = Utils::Callbacks::Chain.new
+
+            class_attribute :around_callbacks
+            self.around_callbacks = Utils::Callbacks::Chain.new
+          end
+        end
+
+        def append_around(&)
+          around_callbacks.append_around(&)
+        end
+
+        alias around append_around
+
+        def append_before(*callbacks, &)
+          before_callbacks.append(*callbacks, &)
+        end
+
+        alias before append_before
+
+        def append_after(*callbacks, &)
+          after_callbacks.append(*callbacks, &)
+        end
+
+        alias after append_after
+
+        def prepend_before(*callbacks, &)
+          before_callbacks.prepend(*callbacks, &)
+        end
+
+        def prepend_after(*callbacks, &)
+          after_callbacks.prepend(*callbacks, &)
+        end
+      end
+
+      # Callbacks API instance methods
+      #
+      # @since 0.1.0
+      # @api private
+      module InstanceMethods
+        # Implements the Rack/Hanami::Action protocol
+        #
+        # @since 0.1.0
+        # @api private
+        def call(params)
+          _run_before_callbacks(params)
+          _run_around_callbacks(params) { super }
+          _run_after_callbacks(params)
+        end
+
+        private
+
+        def _run_before_callbacks(params)
+          self.class.before_callbacks.run(self, params)
+        end
+
+        def _run_after_callbacks(params)
+          self.class.after_callbacks.run(self, params)
+        end
+
+        def _run_around_callbacks(params, &block)
+          chain = self.class.around_callbacks.chain
+          return block.call if chain.empty?
+
+          execute_around_chain(chain.dup, params, &block)
+        end
+
+        # We cannot use Hanami::Utils::Callbacks::Chain#run method
+        # since it always call all callbacks sequentially. Instead,
+        # we want to have each callback able to control to call the
+        # next block or not (in case it want to return early)
+        def execute_around_chain(chain, params, &block)
+          if chain.empty?
+            block.call
+          else
+            callback = chain.shift
+            callback.call(self, params) { execute_around_chain(chain, params, &block) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/utils/callbacks.rb
+++ b/lib/hanami/utils/callbacks.rb
@@ -1,0 +1,306 @@
+# frozen_string_literal: true
+
+module Hanami
+  module Utils
+    # Before and After callbacks
+    #
+    # @since 0.1.0
+    # @private
+    module Callbacks
+      # Series of callbacks to be executed
+      #
+      # @since 0.1.0
+      # @private
+      class Chain
+        # Returns a new chain
+        #
+        # @return [Hanami::Utils::Callbacks::Chain]
+        #
+        # @since 0.2.0
+        def initialize
+          @chain = []
+        end
+
+        attr_reader :chain
+
+        # Appends the given callbacks to the end of the chain.
+        #
+        # @param callbacks [Array] one or multiple callbacks to append
+        # @param block [Proc] an optional block to be appended
+        #
+        # @return [void]
+        #
+        # @raise [RuntimeError] if the object was previously frozen
+        #
+        # @see #prepend
+        # @see #run
+        # @see Hanami::Utils::Callbacks::Callback
+        # @see Hanami::Utils::Callbacks::MethodCallback
+        # @see Hanami::Utils::Callbacks::Chain#freeze
+        #
+        # @since 0.3.4
+        #
+        # @example
+        #   require 'hanami/utils/callbacks'
+        #
+        #   chain = Hanami::Utils::Callbacks::Chain.new
+        #
+        #   # Append a Proc to be used as a callback, it will be wrapped by `Callback`
+        #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
+        #   chain.append { Authenticator.authenticate! }
+        #   chain.append { |params| ArticleRepository.new.find(params[:id]) }
+        #
+        #   # Append a Symbol as a reference to a method name that will be used as a callback.
+        #   # It will wrapped by `MethodCallback`
+        #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
+        #   chain.append :notificate
+        def append(*callbacks, &block)
+          callables(callbacks, block).each do |c|
+            @chain.push(c)
+          end
+
+          @chain.uniq!
+        end
+
+        def append_around(&block)
+          @chain.push(AroundCallback.new(block))
+        end
+
+        # Prepends the given callbacks to the beginning of the chain.
+        #
+        # @param callbacks [Array] one or multiple callbacks to add
+        # @param block [Proc] an optional block to be added
+        #
+        # @return [void]
+        #
+        # @raise [RuntimeError] if the object was previously frozen
+        #
+        # @see #append
+        # @see #run
+        # @see Hanami::Utils::Callbacks::Callback
+        # @see Hanami::Utils::Callbacks::MethodCallback
+        # @see Hanami::Utils::Callbacks::Chain#freeze
+        #
+        # @since 0.3.4
+        #
+        # @example
+        #   require 'hanami/utils/callbacks'
+        #
+        #   chain = Hanami::Utils::Callbacks::Chain.new
+        #
+        #   # Add a Proc to be used as a callback, it will be wrapped by `Callback`
+        #   # The optional argument(s) correspond to the one passed when invoked the chain with `run`.
+        #   chain.prepend { Authenticator.authenticate! }
+        #   chain.prepend { |params| ArticleRepository.new.find(params[:id]) }
+        #
+        #   # Add a Symbol as a reference to a method name that will be used as a callback.
+        #   # It will wrapped by `MethodCallback`
+        #   # If the #notificate method accepts some argument(s) they should be passed when `run` is invoked.
+        #   chain.prepend :notificate
+        def prepend(*callbacks, &block)
+          callables(callbacks, block).each do |c|
+            @chain.unshift(c)
+          end
+
+          @chain.uniq!
+        end
+
+        # Runs all the callbacks in the chain.
+        # The only two ways to stop the execution are: `raise` or `throw`.
+        #
+        # @param context [Object] the context where we want the chain to be invoked.
+        # @param args [Array] the arguments that we want to pass to each single callback.
+        #
+        # @since 0.1.0
+        #
+        # @example
+        #   require 'hanami/utils/callbacks'
+        #
+        #   class Action
+        #     private
+        #     def authenticate!
+        #     end
+        #
+        #     def set_article(params)
+        #     end
+        #   end
+        #
+        #   action = Action.new
+        #   params = Hash[id: 23]
+        #
+        #   chain = Hanami::Utils::Callbacks::Chain.new
+        #   chain.append :authenticate!, :set_article
+        #
+        #   chain.run(action, params)
+        #
+        #   # `params` will only be passed as #set_article argument, because it has an arity greater than zero
+        #
+        #
+        #
+        #   chain = Hanami::Utils::Callbacks::Chain.new
+        #
+        #   chain.append do
+        #     # some authentication logic
+        #   end
+        #
+        #   chain.append do |params|
+        #     # some other logic that requires `params`
+        #   end
+        #
+        #   chain.run(action, params)
+        #
+        #   Those callbacks will be invoked within the context of `action`.
+        def run(context, *args)
+          @chain.each do |callback|
+            callback.call(context, *args)
+          end
+        end
+
+        # It freezes the object by preventing further modifications.
+        #
+        # @since 0.2.0
+        #
+        # @see http://ruby-doc.org/core/Object.html#method-i-freeze
+        #
+        # @example
+        #   require 'hanami/utils/callbacks'
+        #
+        #   chain = Hanami::Utils::Callbacks::Chain.new
+        #   chain.freeze
+        #
+        #   chain.frozen?  # => true
+        #
+        #   chain.append :authenticate! # => RuntimeError
+        def freeze
+          super
+          @chain.freeze
+        end
+
+        private
+
+        # @api private
+        def callables(callbacks, block)
+          callbacks.push(block) if block
+          callbacks.map { |c| Factory.fabricate(c) }
+        end
+      end
+
+      # Callback factory
+      #
+      # @since 0.1.0
+      # @api private
+      class Factory
+        # Instantiates a `Callback` according to if it responds to #call.
+        #
+        # @param callback [Object] the object that needs to be wrapped
+        #
+        # @return [Callback, MethodCallback]
+        #
+        # @since 0.1.0
+        #
+        # @example
+        #   require 'hanami/utils/callbacks'
+        #
+        #   callable = Proc.new{} # it responds to #call
+        #   method   = :upcase    # it doesn't responds to #call
+        #
+        #   Hanami::Utils::Callbacks::Factory.fabricate(callable).class
+        #     # => Hanami::Utils::Callbacks::Callback
+        #
+        #   Hanami::Utils::Callbacks::Factory.fabricate(method).class
+        #     # => Hanami::Utils::Callbacks::MethodCallback
+        def self.fabricate(callback)
+          if callback.respond_to?(:call)
+            Callback.new(callback)
+          else
+            MethodCallback.new(callback)
+          end
+        end
+      end
+
+      # Proc callback
+      # It wraps an object that responds to #call
+      #
+      # @since 0.1.0
+      # @api private
+      class Callback
+        # @api private
+        attr_reader :callback
+
+        # Initialize by wrapping the given callback
+        #
+        # @param callback [Object] the original callback that needs to be wrapped
+        #
+        # @return [Callback] self
+        #
+        # @since 0.1.0
+        # @api private
+        def initialize(callback)
+          @callback = callback
+        end
+
+        # Executes the callback within the given context and passing the given arguments.
+        #
+        # @param context [Object] the context within we want to execute the callback.
+        # @param args [Array] an array of arguments that will be available within the execution.
+        #
+        # @return [void, Object] It may return a value, it depends on the callback.
+        #
+        # @since 0.1.0
+        # @api private
+        #
+        # @see Hanami::Utils::Callbacks::Chain#run
+        def call(context, *args)
+          context.instance_exec(*args, &callback)
+        end
+      end
+
+      class AroundCallback < Callback
+        def call(context, *args, &block)
+          context.instance_exec(*args, block, &callback)
+        end
+      end
+
+      # Method callback
+      #
+      # It wraps a symbol or a string representing a method name that is
+      # implemented by the context within it will be called.
+      #
+      # @since 0.1.0
+      # @api private
+      class MethodCallback < Callback
+        # Executes the callback within the given context and eventually passing the given arguments.
+        # Those arguments will be passed according to the arity of the target method.
+        #
+        # @param context [Object] the context within we want to execute the callback.
+        # @param args [Array] an array of arguments that will be available within the execution.
+        #
+        # @return [void, Object] It may return a value, it depends on the callback.
+        #
+        # @since 0.1.0
+        # @api private
+        #
+        # @see Hanami::Utils::Callbacks::Chain#run
+        def call(context, *args)
+          method = context.method(callback)
+
+          if method.parameters.any?
+            method.call(*args)
+          else
+            method.call
+          end
+        end
+
+        # @api private
+        def hash
+          callback.hash
+        end
+
+        # @api private
+        def eql?(other)
+          hash == other.hash
+        end
+      end
+    end
+  end
+end

--- a/spec/hanami/action/callbacks_spec.rb
+++ b/spec/hanami/action/callbacks_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'hanami-controller'
+require_relative '../../../lib/hanami/action/callbacks'
+require_relative '../../../lib/hanami/utils/callbacks'
+
+RSpec.describe Hanami::Action::Callbacks do
+  describe 'callbacks' do
+    let(:action) { CallbacksAction.new }
+
+    class CallbacksAction # rubocop:disable Lint/ConstantDefinitionInBlock
+      include Hanami::Action::Callbacks
+
+      def self.reset!
+        @before_callbacks = Hanami::Utils::Callbacks::Chain.new
+        @after_callbacks = Hanami::Utils::Callbacks::Chain.new
+        @around_callbacks = Hanami::Utils::Callbacks::Chain.new
+      end
+
+      def call(params); end
+    end
+
+    before do
+      CallbacksAction.reset!
+    end
+
+    describe 'around callbacks' do
+      it 'executes around callbacks in the correct order' do
+        executed_order = []
+
+        CallbacksAction.class_eval do
+          around do |_params, action|
+            executed_order << :before_first
+            action.call
+            executed_order << :after_first
+          end
+
+          around do |_params, action|
+            executed_order << :before_second
+            action.call
+            executed_order << :after_second
+          end
+
+          def call(executed_order)
+            executed_order << :action
+          end
+        end
+
+        action.call(executed_order)
+
+        expect(executed_order).to eq(
+          %i[
+            before_first
+            before_second
+            action
+            after_second
+            after_first
+          ]
+        )
+      end
+
+      it 'allows early return from around callbacks' do
+        executed_order = []
+
+        CallbacksAction.class_eval do
+          around do |_params, _action|
+            executed_order << :before_first
+          end
+
+          around do |_params, action|
+            executed_order << :before_second
+            action.call
+            executed_order << :after_second
+          end
+
+          def call(executed_order)
+            executed_order << :action
+          end
+        end
+
+        action.call(executed_order)
+
+        expect(executed_order).to eq(%i[before_first])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Jira ticket: https://kaligo.atlassian.net/browse/GHP-4209

## Design

This PR monkey patches Hanami 1.3 to support `around` callback. This `around` callback only supports the block version at the moment. Adding support for `around :method_name` is possible, but it is unnecessarily at the moment so I'll skip it in this PR

The entry point for review shall be in `lib/hanami/action/callbacks.rb` where we implement the `append_around` callback