### PR TITLE
[GHP-4251] Emit metrics via datadog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Change Log]
 
+## [0.1.4] - 2025-01-14
+
+- Support instrumentation via event hook approach
+- Support metrics logging via StatsdListener
+
+## [0.1.3] - 2025-01-14
+
+- Support testing by mocking MockRedis#evalsha
+
+## [0.1.2] - 2025-01-07
+
+- Support auto-releasing gem
+
+## [0.1.1] - 2025-01-07
+
+- Allow configuring idempotent methods instead of hardcoding POST
+
 ## [0.1.0] - 2024-11-13
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [0.1.4] - 2025-01-14
 
-- Support instrumentation via event hook approach
 - Support metrics logging via StatsdListener
 
 ## [0.1.3] - 2025-01-14

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'mock_redis'
 gem 'rspec', '~> 3.0'
 
 gem 'connection_pool'
+gem 'dry-monitor'
 gem 'hanami-controller', '~> 1.3'
 gem 'pry-byebug'
 gem 'rubocop', '~> 1.21'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     idempotency (0.1.2)
       base64
       dry-configurable
+      dry-monitor
       msgpack
       redis
 
@@ -24,6 +25,13 @@ GEM
       concurrent-ruby (~> 1.0)
       logger
       zeitwerk (~> 2.6)
+    dry-events (1.0.1)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+    dry-monitor (1.0.1)
+      dry-configurable (~> 1.0, < 2)
+      dry-core (~> 1.0, < 2)
+      dry-events (~> 1.0, < 2)
     hanami-controller (1.3.3)
       hanami-utils (~> 1.3)
       rack (~> 2.0)
@@ -90,6 +98,7 @@ PLATFORMS
 
 DEPENDENCIES
   connection_pool
+  dry-monitor
   hanami-controller (~> 1.3)
   idempotency!
   mock_redis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    idempotency (0.1.3)
+    idempotency (0.1.4)
       base64
       dry-configurable
       dry-monitor

--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ Idempotency.configure do |config|
   }
 
   config.idempotent_methods = %w[POST PUT PATCH]
-  config.idempotent_statuses = (200..299).to_a
+  config.idempotent_statuses = (200..299).to_a + (400..499).to_a
+
+  # Metrics configuration
+  config.metrics.statsd_client = statsd_client # Your StatsD client instance
+  config.metrics.namespace = 'my_service_name' # Optional namespace for metrics
+
+  # Custom instrumentation listeners (optional)
+  config.instrumentation_listeners = [my_custom_listener] # Array of custom listeners
 end
 ```
 
@@ -102,7 +109,7 @@ end
 
 ### Instrumentation
 
-The gem supports instrumentation through StatsD. It tracks the following metrics:
+The gem supports instrumentation through StatsD out of the box. When you configure a StatsD client in the configuration, the StatsdListener will be automatically set up. It tracks the following metrics:
 
 - `idempotency_cache_hit_count` - Incremented when a cached response is found
 - `idempotency_cache_miss_count` - Incremented when no cached response exists
@@ -114,17 +121,11 @@ Each metric includes tags:
 - `namespace` - Your configured namespace (if provided)
 - `metric` - The metric name (for duration histogram only)
 
-To enable above instrumentation, configure a StatsD listener:
+To enable StatsD instrumentation, simply configure the metrics settings:
 
 ```ruby
-statsd_client = Datadog::Statsd.new
-statsd_listener = Idempotency::Instrumentation::StatsdListener.new(
-  statsd_client,
-  'my_service_name'
-)
-
 Idempotency.configure do |config|
-  config.instrumentation_listeners = [statsd_listener]
+  config.metrics.statsd_client = Datadog::Statsd.new
+  config.metrics.namespace = 'my_service_name'
 end
 ```
-

--- a/README.md
+++ b/README.md
@@ -100,3 +100,31 @@ RSpec.configure do |config|
 end
 ```
 
+### Instrumentation
+
+The gem supports instrumentation through StatsD. It tracks the following metrics:
+
+- `idempotency_cache_hit_count` - Incremented when a cached response is found
+- `idempotency_cache_miss_count` - Incremented when no cached response exists
+- `idempotency_lock_conflict_count` - Incremented when concurrent requests conflict
+- `idempotency_cache_duration_seconds` - Histogram of operation duration
+
+Each metric includes tags:
+- `action` - Either the specified action name or `"{HTTP_METHOD}:{PATH}"`
+- `namespace` - Your configured namespace (if provided)
+- `metric` - The metric name (for duration histogram only)
+
+To enable above instrumentation, configure a StatsD listener:
+
+```ruby
+statsd_client = Datadog::Statsd.new
+statsd_listener = Idempotency::Instrumentation::StatsdListener.new(
+  statsd_client,
+  'my_service_name'
+)
+
+Idempotency.configure do |config|
+  config.instrumentation_listeners = [statsd_listener]
+end
+```
+

--- a/idempotency.gemspec
+++ b/idempotency.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'base64'
   spec.add_dependency 'dry-configurable'
+  spec.add_dependency 'dry-monitor'
   spec.add_dependency 'msgpack'
   spec.add_dependency 'redis'
 end

--- a/lib/idempotency.rb
+++ b/lib/idempotency.rb
@@ -23,6 +23,10 @@ class Idempotency
   setting :redis_pool
   setting :logger
   setting :instrumentation_listeners, default: []
+  setting :metrics do
+    setting :namespace
+    setting :statsd_client
+  end
 
   setting :default_lock_expiry, default: 300 # 5 minutes
   setting :idempotent_methods, default: %w[POST PUT PATCH DELETE]
@@ -36,6 +40,13 @@ class Idempotency
 
   def self.configure
     super
+
+    if config.metrics.statsd_client
+      config.instrumentation_listeners << Idempotency::Instrumentation::StatsdListener.new(
+        config.metrics.statsd_client,
+        config.metrics.namespace
+      )
+    end
 
     config.instrumentation_listeners.each(&:setup_subscriptions)
   end

--- a/lib/idempotency/constants.rb
+++ b/lib/idempotency/constants.rb
@@ -5,4 +5,12 @@ class Idempotency
     RACK_HEADER_KEY = 'HTTP_IDEMPOTENCY_KEY'
     HEADER_KEY = 'Idempotency-Key'
   end
+
+  module Events
+    ALL_EVENTS = [
+      CACHE_HIT = :cache_hit,
+      CACHE_MISS = :cache_miss,
+      LOCK_CONFLICT = :lock_conflict
+    ].freeze
+  end
 end

--- a/lib/idempotency/hanami.rb
+++ b/lib/idempotency/hanami.rb
@@ -4,9 +4,9 @@ require_relative '../idempotency'
 
 class Idempotency
   module Hanami
-    def use_cache(request_identifiers = [], lock_duration: nil)
+    def use_cache(request_identifiers = [], lock_duration: nil, action: self.class.name)
       response_status, response_headers, response_body = Idempotency.use_cache(
-        request, request_identifiers, lock_duration:
+        request, request_identifiers, lock_duration:, action:
       ) do
         yield
 

--- a/lib/idempotency/instrumentation/statsd_listener.rb
+++ b/lib/idempotency/instrumentation/statsd_listener.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../../idempotency'
+
+class Idempotency
+  module Instrumentation
+    class StatsdListener
+      EVENT_NAME_TO_METRIC_MAPPINGS = {
+        Events::CACHE_HIT => 'idempotency_cache_hit_count',
+        Events::CACHE_MISS => 'idempotency_cache_miss_count',
+        Events::LOCK_CONFLICT => 'idempotency_lock_conflict_count'
+      }.freeze
+
+      def initialize(statsd_client, namespace = nil)
+        @statsd_client = statsd_client
+        @namespace = namespace
+      end
+
+      def setup_subscriptions
+        EVENT_NAME_TO_METRIC_MAPPINGS.each do |event_name, metric|
+          Idempotency.notifier.subscribe(event_name) do |event|
+            send_metric(metric, event.payload)
+          end
+        end
+      end
+
+      private
+
+      attr_reader :namespace, :statsd_client
+
+      def send_metric(metric_name, event_data)
+        action = event_data[:action] || "#{event_data[:request].request_method}:#{event_data[:request].path}"
+        tags = ["action:#{action}"]
+        tags << "namespace:#{@namespace}" if @namespace
+
+        @statsd_client.increment(metric_name, tags:)
+        @statsd_client.histogram(
+          'idempotency_cache_duration_seconds', event_data[:duration], tags: tags + ["metric:#{metric_name}"]
+        )
+      end
+    end
+  end
+end

--- a/lib/idempotency/rails.rb
+++ b/lib/idempotency/rails.rb
@@ -4,9 +4,9 @@ require_relative '../idempotency'
 
 class Idempotency
   module Rails
-    def use_cache(request_identifiers = [], lock_duration: nil)
+    def use_cache(request_identifiers = [], lock_duration: nil, action: "#{controller_name}##{action_name}")
       response_status, response_headers, response_body = Idempotency.use_cache(
-        request, request_identifiers, lock_duration:
+        request, request_identifiers, lock_duration:, action:
       ) do
         yield
 

--- a/lib/idempotency/version.rb
+++ b/lib/idempotency/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Idempotency
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/idempotency/instrumentation/datadog_listener_spec.rb
+++ b/spec/idempotency/instrumentation/datadog_listener_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+RSpec.describe Idempotency::Instrumentation::StatsdListener do
+  let(:statsd_client) { double('statsd_client') }
+  let(:namespace) { 'test_app' }
+  let(:listener) { described_class.new(statsd_client, namespace) }
+  let(:request) do
+    double(
+      'Request',
+      request_method: 'POST',
+      path: '/orders/123'
+    )
+  end
+  let(:event_payload) do
+    {
+      request: request,
+      action: 'POST:/orders/create',
+      duration: 0.1
+    }
+  end
+  let(:notifier) do
+    Dry::Monitor::Notifications.new(:test).tap do |n|
+      Idempotency::Events::ALL_EVENTS.each { |event| n.register_event(event) }
+    end
+  end
+
+  before do
+    allow(Idempotency).to receive(:notifier).and_return(notifier)
+    listener.setup_subscriptions
+  end
+
+  context 'when cache hit event is triggered' do
+    it 'sends correct metrics' do
+      expect(statsd_client).to receive(:increment).with(
+        'idempotency_cache_hit_count',
+        tags: ['action:POST:/orders/create', 'namespace:test_app']
+      )
+      expect(statsd_client).to receive(:histogram).with(
+        'idempotency_cache_duration_seconds',
+        0.1,
+        tags: [
+          'action:POST:/orders/create',
+          'namespace:test_app',
+          'metric:idempotency_cache_hit_count'
+        ]
+      )
+
+      Idempotency.notifier.instrument(Idempotency::Events::CACHE_HIT, event_payload)
+    end
+  end
+
+  context 'when cache miss event is triggered' do
+    it 'sends correct metrics' do
+      expect(statsd_client).to receive(:increment).with(
+        'idempotency_cache_miss_count',
+        tags: ['action:POST:/orders/create', 'namespace:test_app']
+      )
+      expect(statsd_client).to receive(:histogram).with(
+        'idempotency_cache_duration_seconds',
+        0.1,
+        tags: [
+          'action:POST:/orders/create',
+          'namespace:test_app',
+          'metric:idempotency_cache_miss_count'
+        ]
+      )
+
+      Idempotency.notifier.instrument(Idempotency::Events::CACHE_MISS, event_payload)
+    end
+  end
+
+  context 'when lock conflict event is triggered' do
+    it 'sends correct metrics' do
+      expect(statsd_client).to receive(:increment).with(
+        'idempotency_lock_conflict_count',
+        tags: ['action:POST:/orders/create', 'namespace:test_app']
+      )
+      expect(statsd_client).to receive(:histogram).with(
+        'idempotency_cache_duration_seconds',
+        0.1,
+        tags: [
+          'action:POST:/orders/create',
+          'namespace:test_app',
+          'metric:idempotency_lock_conflict_count'
+        ]
+      )
+
+      Idempotency.notifier.instrument(Idempotency::Events::LOCK_CONFLICT, event_payload)
+    end
+  end
+
+  context 'when action is not provided' do
+    let(:event_payload) do
+      {
+        request: request,
+        duration: 0.1
+      }
+    end
+
+    it 'uses request method and path as action' do
+      expect(statsd_client).to receive(:increment).with(
+        'idempotency_cache_hit_count',
+        tags: ['action:POST:/orders/123', 'namespace:test_app']
+      )
+      expect(statsd_client).to receive(:histogram).with(
+        'idempotency_cache_duration_seconds',
+        0.1,
+        tags: [
+          'action:POST:/orders/123',
+          'namespace:test_app',
+          'metric:idempotency_cache_hit_count'
+        ]
+      )
+
+      Idempotency.notifier.instrument(Idempotency::Events::CACHE_HIT, event_payload)
+    end
+  end
+
+  context 'when namespace is not provided' do
+    let(:listener) { described_class.new(statsd_client) }
+
+    it 'does not include namespace tag' do
+      expect(statsd_client).to receive(:increment).with(
+        'idempotency_cache_hit_count',
+        tags: ['action:POST:/orders/create']
+      )
+      expect(statsd_client).to receive(:histogram).with(
+        'idempotency_cache_duration_seconds',
+        0.1,
+        tags: [
+          'action:POST:/orders/create',
+          'metric:idempotency_cache_hit_count'
+        ]
+      )
+
+      Idempotency.notifier.instrument(Idempotency::Events::CACHE_HIT, event_payload)
+    end
+  end
+end

--- a/spec/idempotency/rails_spec.rb
+++ b/spec/idempotency/rails_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Idempotency::Rails do
       response.status = status
     end
 
+    def controller_name
+      'orders'
+    end
+
+    def action_name
+      'create'
+    end
+
     private
 
     attr_reader :request, :response


### PR DESCRIPTION
## Context

Jira ticket: https://kaligo.atlassian.net/browse/GHP-4251

## Design

This PR allows client to configure datadog client as well as the metric namespace.

We will log out the following metrics based on the flow of our gem:
```
idempotency_cache_hit_count
idempotency_cache_miss_count
idempotency_lock_conflict_count
idempotency_cache_duration_seconds
```

There is one note:
- We want the API path to be included as metric tags, however, the number of API paths can be unbound since it can be dynamic (like `PATCH /users/<user-id>`). 
- To prevent having unbound values of this API paths, `use_cache` method now accepts an `action` argument to be used in place of the API path metric tag, so application side can provide a value that filter out the dynamic part. This is probably not the most intuitive interface but I've yet to find any other better workaround