### PR TITLE
Support testing by mocking MockRedis#evalsha

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    idempotency (0.1.2)
+    idempotency (0.1.3)
       base64
       dry-configurable
       msgpack

--- a/README.md
+++ b/README.md
@@ -89,3 +89,14 @@ end
 
 # Render your response
 ```
+
+### Testing
+
+For those using `mock_redis` gem, some methods that `idempotency` gem uses are not implemented (e.g. eval, evalsha), and this could cause test cases to fail. To get around this, the gem has a monkeypatch over `mock_redis` gem to override the missing methods. To use it, simply add following lines to your `spec_helper.rb`:
+
+```ruby
+RSpec.configure do |config|
+  config.include Idempotency::Testing::Helpers
+end
+```
+

--- a/lib/idempotency/testing/helpers.rb
+++ b/lib/idempotency/testing/helpers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'idempotency/cache'
+
+class Idempotency
+  module Testing
+    module Helpers
+      def self.included(_base)
+        return unless defined?(MockRedis)
+
+        MockRedis.class_eval do
+          def evalsha(sha, keys:, argv:)
+            return unless sha == Idempotency::Cache::COMPARE_AND_DEL_SCRIPT_SHA
+
+            value = argv[0]
+            cached_value = get(keys[0])
+
+            if value == cached_value
+              del(keys[0])
+              value
+            else
+              cached_value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/idempotency/version.rb
+++ b/lib/idempotency/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Idempotency
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
## Context

Application uses `MockRedis` will have test cases related to Idempotency cache failing due to the `Idempotency::Cache#evalsha` method always return `nil`, which causes the `release_lock` logic to always fail:

```
    def release_lock(fingerprint, acquired_lock)
      with_redis do |r|
        lock_released = r.evalsha(COMPARE_AND_DEL_SCRIPT_SHA, keys: [lock_key(fingerprint)], argv: [acquired_lock])
		# lock_released is always `nil` which will differ from `acquired_lock` value
        raise LockConflict if lock_released != acquired_lock
```

As such, I've created a new helper in this PR to override the `evalsha` implementation of MockRedis to work similar to the LUA script logic