### PR TITLE
Set 1 day expiration time for idempotent response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Change Log]
 
+## [0.1.5] - 2025-02-04
+
+- Set correct expiration time for idempotency cache
+
 ## [0.1.4] - 2025-01-14
 
 - Support metrics logging via StatsdListener
@@ -19,4 +23,3 @@
 ## [0.1.0] - 2024-11-13
 
 - Initial release
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    idempotency (0.1.4)
+    idempotency (0.1.5)
       base64
       dry-configurable
       dry-monitor

--- a/lib/idempotency/cache.rb
+++ b/lib/idempotency/cache.rb
@@ -43,7 +43,7 @@ class Idempotency
       key = response_cache_key(fingerprint)
 
       with_redis do |r|
-        r.set(key, serialize(response_status, response_headers, response_body))
+        r.set(key, serialize(response_status, response_headers, response_body), ex: DEFAULT_CACHE_EXPIRY)
       end
     end
 

--- a/lib/idempotency/version.rb
+++ b/lib/idempotency/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Idempotency
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/spec/idempotency/cache_spec.rb
+++ b/spec/idempotency/cache_spec.rb
@@ -46,8 +46,9 @@ RSpec.describe Idempotency::Cache do
     let(:response_headers) { { 'header' => 'valuee' } }
 
     it 'sets data in cache correctly' do
-      is_expected.to eq('OK')
+      expect(subject).to eq('OK')
       expect(cache.get(fingerprint)).to eq([response_status, response_body, response_headers])
+      expect(mock_redis.ttl("idempotency:cached_response:#{fingerprint}")).to eq(86_400)
     end
   end
 


### PR DESCRIPTION
We need to set the cache expiry for idempotency response properly so that it could be expired after one day